### PR TITLE
Fix `expo start --web`

### DIFF
--- a/App.js
+++ b/App.js
@@ -11,9 +11,7 @@ import {
 import { Login } from './screens/Login';
 import { Home } from './screens/Home';
 import { AuthLoading } from './screens/AuthLoading';
-import Reactotron from 'reactotron-react-native';
-
-/* global __DEV__ */
+import './Reactotron';
 
 const client = new ApolloClient({
   uri: 'https://yarc-app.herokuapp.com',
@@ -31,6 +29,7 @@ const client = new ApolloClient({
 const AppStack = createStackNavigator(
   { Home: Home }
 );
+
 const AuthStack = createStackNavigator(
   { Login: Login }
 );
@@ -47,17 +46,6 @@ const AppWrapper = createAppContainer(createSwitchNavigator(
 ));
 
 export default function App() {
-  if (__DEV__) {
-    // Reactotron is a RN inspector for
-    // easier debugging. Change the `host` key
-    // with your Expo IP.
-    // https://github.com/infinitered/reactotron/
-    Reactotron
-      .configure({ host: '192.168.1.4' })
-      .useReactNative()
-      .connect();
-  }
-
   return (
     <ApolloProvider client={client}>
       <AppWrapper />

--- a/Reactotron.native.js
+++ b/Reactotron.native.js
@@ -1,0 +1,12 @@
+import Reactotron from 'reactotron-react-native';
+
+/* global __DEV__ */
+
+// Reactotron is a RN inspector for
+// easier debugging. Change .configure() to
+//  .configure({ host: '<your Expo IP>' })
+// https://github.com/infinitered/reactotron/
+__DEV__ && Reactotron
+  .configure()
+  .useReactNative()
+  .connect();

--- a/Reactotron.web.js
+++ b/Reactotron.web.js
@@ -1,0 +1,7 @@
+import Reactotron from 'reactotron-react-js';
+
+/* global __DEV__ */
+
+__DEV__ && Reactotron
+  .configure()
+  .connect();

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-preset-expo": "^5.1.1",
     "eslint": "^6.3.0",
     "eslint-plugin-react": "^7.14.3",
+    "reactotron-react-js": "^3.3.2",
     "reactotron-react-native": "^3.6.4"
   },
   "private": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -2115,6 +2115,13 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+error-stack-parser@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.3.tgz#9d3c000fb9f5c461f7c4e63c1aa75373ac7aaa36"
+  integrity sha512-vRC4rKv87twMZy92X4+TmUdv3iYMsmePbpG/YguHsfzmZ8bYJZYYep7yrXH09yFUaCEPKgNK5X79+Yq7hwLVOA==
+  dependencies:
+    stackframe "^1.0.4"
+
 errorhandler@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/errorhandler/-/errorhandler-1.5.1.tgz#b9ba5d17cf90744cd1e851357a6e75bf806a9a91"
@@ -5385,6 +5392,14 @@ reactotron-core-client@2.8.3:
   resolved "https://registry.yarnpkg.com/reactotron-core-client/-/reactotron-core-client-2.8.3.tgz#e8ce782f21ba3c04eb3c678297edceac283857ff"
   integrity sha512-TAidkKZvU2KyCSkRyorLm0RZ/8KnYMIWsawyMsXcSNm2aEOku/5RbBh/7yPNZHU1X7199UMs4T1TAedlK6/w6A==
 
+reactotron-react-js@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/reactotron-react-js/-/reactotron-react-js-3.3.2.tgz#79e53e67d042f07103d27d15a77eaa253851203d"
+  integrity sha512-sjKk1VA8G0WbKCG+/1WNBz4rEGnyAL5oeNeXlNNowGPYLy2F6BkkShb2YddDtTeUIfL6Dy/ubJinjgtla9+DIQ==
+  dependencies:
+    reactotron-core-client "2.8.3"
+    stacktrace-js "2.0.0"
+
 reactotron-react-native@^3.6.4:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/reactotron-react-native/-/reactotron-react-native-3.6.4.tgz#a3e3bbdd8d1a76539855f2b970ed33d810fe39af"
@@ -5893,6 +5908,11 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
+source-map@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
+  integrity sha1-dc449SvwczxafwwRjYEzSiu19BI=
+
 source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
@@ -5945,6 +5965,35 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+stack-generator@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-2.0.3.tgz#bb74385c67ffc4ccf3c4dee5831832d4e509c8a0"
+  integrity sha512-kdzGoqrnqsMxOEuXsXyQTmvWXZmG0f3Ql2GDx5NtmZs59sT2Bt9Vdyq0XdtxUi58q/+nxtbF9KOQ9HkV1QznGg==
+  dependencies:
+    stackframe "^1.0.4"
+
+stackframe@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.0.4.tgz#357b24a992f9427cba6b545d96a14ed2cbca187b"
+  integrity sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw==
+
+stacktrace-gps@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/stacktrace-gps/-/stacktrace-gps-3.0.2.tgz#33f8baa4467323ab2bd1816efa279942ba431ccc"
+  integrity sha512-9o+nWhiz5wFnrB3hBHs2PTyYrS60M1vvpSzHxwxnIbtY2q9Nt51hZvhrG1+2AxD374ecwyS+IUwfkHRE/2zuGg==
+  dependencies:
+    source-map "0.5.6"
+    stackframe "^1.0.4"
+
+stacktrace-js@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/stacktrace-js/-/stacktrace-js-2.0.0.tgz#776ca646a95bc6c6b2b90776536a7fc72c6ddb58"
+  integrity sha1-d2ymRqlbxsayuQd2U2p/xyxt21g=
+  dependencies:
+    error-stack-parser "^2.0.1"
+    stack-generator "^2.0.1"
+    stacktrace-gps "^3.0.1"
 
 stacktrace-parser@0.1.4:
   version "0.1.4"


### PR DESCRIPTION
`import Reactotron from 'reactotron-react-native'` non funziona con webpack ⚠️

`reactotron-react-native` importa [XHRInterceptor](https://github.com/infinitered/reactotron-react-native/blob/053361b66f720447426f73cb5f40483952510ae8/src/plugins/networking.ts#L1) da `react-native`, qui il modulo `XMLHttpRequest` (immagino un polyfill della versione web) importa [RCTNetworking](https://github.com/expo/react-native/blob/72ad6687327eb4c0bf08ff03c5852d08235b9506/Libraries/Network/XMLHttpRequest.js#L15) che ha solo un'implementazione nativa.

Possiamo includere `reactotron-react-js` per usare reactotron anche in browser 🥳