### PR TITLE
Automatic stub generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "lint": "eslint .",
+    "gen": "hitbit-stub",
     "eject": "expo eject"
   },
   "dependencies": {
@@ -29,6 +30,7 @@
     "react-navigation": "^3.11.1"
   },
   "devDependencies": {
+    "@hitbit/stubs": "0.0.7",
     "babel-preset-expo": "^7.0.0",
     "eslint": "^6.5.1",
     "eslint-plugin-react": "^7.14.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,6 +981,11 @@
     pouchdb-collections "^1.0.1"
     tiny-queue "^0.2.1"
 
+"@hitbit/stubs@0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@hitbit/stubs/-/stubs-0.0.7.tgz#fb7a893bd68fc6095f1a2aa10408c31e59c49765"
+  integrity sha512-txY5cxgm7bszCfuBuNzRuAAfbzimqcwVR/4l6ZcfN2B2KEnj5IzhrGNyExMCtCR7aFXE34njKMJUMsrtXRjZeQ==
+
 "@react-native-community/cli@^1.2.1":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-1.10.0.tgz#66e3c9f407763281f7060c034145650bf0d6786c"


### PR DESCRIPTION
Generare componenti in automatico da uno stub è 😎, ma trovo scomodo configurare gli strumenti per aderire a tutte le convenzioni che abbiamo deciso di adottare. Visto che creare uno script era molto semplice ho pensato di fare questa proposta:

`yarn gen component Test` produce questo
```
app
└── components
    └── Test
        ├── index.js
        └── Test.js
```
### index.js
```javascript
export { Test } from './Test';
```
### Test.js
```javascript
import React from 'react';
import { View, Text } from 'react-native';

export function Test(props) {
  return (
    <View>
      <Text>hello, world</Text>
    </View>
  );
}
```

`yarn gen screen Test` fa la stessa cosa in `screens`
```
app
└── screens
    └── Test
        ├── index.js
        └── Test.js
```

As a bonus: ho creato l'org [hitbit](https://www.npmjs.com/org/hitbit) su npm (che fa super fico) 🎉

Fatemi sapere che ne pensate 👋
